### PR TITLE
Can now load images from any domain

### DIFF
--- a/close-pixelate.js
+++ b/close-pixelate.js
@@ -3,17 +3,39 @@ var ROOT2 = Math.sqrt(2);
 // checking for canvas support
 var supportsCanvas = !!document.createElement('canvas').getContext;
 
+var isLocalURL = (function() {
+
+    var page = document.location,
+        protocol = page.protocol,
+        domain = document.domain,
+        port = page.port ? page.port : '',
+        has_protocol_regex = /^http(?:s*)/,
+        closure = function (url) 
+        {
+            var no_protocol = !has_protocol_regex.test(url),
+                sop_string = protocol + '//' + port + domain,
+                sop_regex = new RegExp('^' + sop_string),
+                is_same_origin = sop_regex.test(url);
+
+            return no_protocol || is_same_origin;
+        };
+
+        return closure;
+})();
+
 HTMLImageElement.prototype.closePixelate = !supportsCanvas ? function(){} : function( renderOptions ) {
+
   // attach render options to image
   this.renderOptions = renderOptions;
 
-  // check if image is already loaded in cache
-  if ( this.complete ) {
-    this.renderClosePixels();
-  } else {
-    this.onload = this.renderClosePixels;
-  }
-
+    if ( isLocalURL( this.src ) ){
+        // check if image is already loaded in cache
+        if ( this.complete ) {
+            this.renderClosePixels();
+        } else {
+            this.onload = this.renderClosePixels;
+        }
+    }
 };
 
 HTMLImageElement.prototype.renderClosePixels = function() {

--- a/examples.html
+++ b/examples.html
@@ -28,7 +28,7 @@
       width: 1600px;
       left: -320px;
     }
-    
+
     a { color: #E58;  text-decoration: none; }
     a:hover { color: #58E; }
 
@@ -36,23 +36,23 @@
       display: block;
       margin-bottom: 6.0em;
     }
-    
+
     figure { display: block; }
-    
+
     figcaption {
       display: block;
       text-align: center;
       margin-bottom: 1.0em;
       font-size: 14px;
     }
-    
+
     article pre {
       width: 600px;
       padding: 1.0em;
       margin: 0 auto;
       border: 1px solid #222;
     }
-    
+
     pre, code {
       font-family: Monaco, monospace;
       font-size: 12px;
@@ -63,20 +63,20 @@
       display: block;
       margin: 0 auto 1.0em;
     }
-    
+
   </style>
-  
+
 
 
 </head>
 <body>
 
   <h1>Close Pixelate Examples</h1>
-  
+
   <div id="portraits-wrap">
-    
+
     <div id="portraits">
-      
+
       <article>
         <figure>
           <img id="officer" class="portrait" src="img/officer.jpg" alt="Chinese officer @ Shanghai downtown market by Dusan Simonovic" />
@@ -154,7 +154,7 @@
         <pre><code>{ shape : 'circle', resolution : 24 },
 { shape : 'circle', resolution : 24, size: 9, offset: 12 }</code></pre>
       </article>
-      
+
       <article>
         <figure>
           <img id="kendra" class="portrait" src="img/kendra.jpg" alt="Kendra by Anna Kreslavskaya" />
@@ -165,7 +165,7 @@
 { shape : 'diamond', resolution : 16, size: 15, offset : 0, alpha : 0.6 },
 { shape : 'diamond', resolution : 16, size: 15, offset : 8, alpha : 0.6 }</code></pre>
       </article>
-      
+
       <article>
         <figure>
           <img id="gavin" class="portrait" src="img/gavin.jpg" alt="Portrait Of A Mayor by Troy Holden" />
@@ -175,9 +175,9 @@
 { shape : 'diamond', resolution : 12, size: 8 },
 { shape : 'diamond', resolution : 12, size: 8, offset : 6 }</code></pre>
       </article>
-      
+
     </div> <!-- #portraits -->
-    
+
   </div> <!-- #portraits-wrap -->
 
 
@@ -242,9 +242,9 @@
         var options = pixelations[key];
         document.getElementById( key ).closePixelate( options );
       }
-      
+
     };
-  
+
     window.addEventListener( 'DOMContentLoaded', docReady, false);
   </script>
 

--- a/examples.html
+++ b/examples.html
@@ -238,15 +238,22 @@
 
     var docReady = function() {
 
-      for ( key in pixelations ) {
+      for ( var key in pixelations ) {
         var options = pixelations[key];
-        document.getElementById( key ).closePixelate( options );
+        async( pixelate(key, pixelations[key]) );
       }
 
     };
 
-    window.addEventListener( 'DOMContentLoaded', docReady, false);
-  </script>
+    function pixelate( id, options){
+        document.getElementById( id ).closePixelate( options );
+    }
+
+    function async( fn ){
+        setTimeout( fn, 0 );
+    }
+
+    window.addEventListener( 'DOMContentLoaded', docReady, false);  </script>
 
 
 </body>

--- a/examples.html
+++ b/examples.html
@@ -168,12 +168,43 @@
 
       <article>
         <figure>
-          <img id="gavin" class="portrait" src="img/gavin.jpg" alt="Portrait Of A Mayor by Troy Holden" />
+          <img id="gavin" class="remote portrait" src="img/gavin.jpg" alt="Portrait Of A Mayor by Troy Holden" />
           <figcaption>Original photo: <a href="http://www.flickr.com/photos/troyholden/4294580760/"><em>Portrait Of A Mayor</em> by Troy Holden</a></figcaption>
         </figure>
         <pre><code>{ shape : 'square', resolution : 48 },
 { shape : 'diamond', resolution : 12, size: 8 },
 { shape : 'diamond', resolution : 12, size: 8, offset : 6 }</code></pre>
+      </article>
+
+      <article>
+        <figure>
+          <img id="london" class="portrait" src="http://farm4.static.flickr.com/3002/2758349058_ab6dc9cfdc_z.jpg?zz=1" />
+          <figcaption>Original photo: <a href="http://www.flickr.com/photos/anniemole/2758349058/" ><em>London Skyline from Altitude 6</em></a> by <a href="http://www.flickr.com/photos/anniemole/" data-target="external">Annie Mole</a></figcaption>
+        </figure>
+        <pre><code>{ shape: 'square', resolution: 32 },
+{ shape: 'circle', resolution: 32, offset: 16 },
+{ shape: 'circle', resolution: 32, offset: 0, alpha: 0.5 },
+{ shape: 'circle', resolution: 16, size: 9, offset: 0, alpha: 0.5 }</code></pre>
+      </article>
+
+      <article>
+        <figure>
+          <img id="sv1" class="remote portrait" src="http://farm1.static.flickr.com/54/156562452_61743d65fa_d.jpg" />
+        </figure>
+        <pre><code>{ shape: 'square', resolution: 32 },
+{ shape: 'circle', resolution: 32, offset: 16 },
+{ shape: 'circle', resolution: 32, offset: 0, alpha: 0.5 },
+{ shape: 'circle', resolution: 16, size: 9, offset: 0, alpha: 0.5 }</code></pre>
+      </article>
+
+      <article>
+        <figure>
+          <img id="sv2" class="remote portrait" src="http://farm1.static.flickr.com/64/156562566_b057ab8105_z_d.jpg?zz=1" />
+        </figure>
+        <pre><code>{ shape: 'square', resolution: 32 },
+{ shape: 'circle', resolution: 32, offset: 16 },
+{ shape: 'circle', resolution: 32, offset: 0, alpha: 0.5 },
+{ shape: 'circle', resolution: 16, size: 9, offset: 0, alpha: 0.5 }</code></pre>
       </article>
 
     </div> <!-- #portraits -->
@@ -232,20 +263,35 @@
       'gavin' : [
         { shape : 'square', resolution : 48 },
         { shape : 'diamond', resolution : 12, size: 8 },
-        { shape : 'diamond', resolution : 12, size: 8, offset : 6 }
+        { shape : 'diamond', resolution : 12, size: 8, offset : 6 },
+      ],
+      'london': [
+        { shape: 'square', resolution: 32 },
+        { shape: 'circle', resolution: 32, offset: 16 },
+        { shape: 'circle', resolution: 32, offset: 0, alpha: 0.5 },
+        { shape: 'circle', resolution: 16, size: 9, offset: 0, alpha: 0.5 }
+      ],
+      'sv1': [
+        { shape: 'diamond', resolution: 24, size: 25 },
+        { shape: 'diamond', resolution: 24, offset: 12 },
+        { resolution: 24, alpha: 0.5 }
+    ],
+      'sv2' : [
+        { shape : 'circle', resolution : 24 },
+        { shape : 'circle', resolution : 24, size: 9, offset: 12 }
       ]
+
     };
 
     var docReady = function() {
 
       for ( var key in pixelations ) {
-        var options = pixelations[key];
-        async( pixelate(key, pixelations[key]) );
+        async( pixelate( key, pixelations[key] ) );
       }
 
     };
 
-    function pixelate( id, options){
+    function pixelate( id, options ){
         document.getElementById( id ).closePixelate( options );
     }
 


### PR DESCRIPTION
It's true :)

Load my copy, add some remote images and give it a whirl. The call signature is the same as before. All your calls from examples.html will still work. 

I added two functions (isLocalURL, getRemoteImageData), restructured closePixelate somewhat and made small changes to renderClosePixels.

I also made some small changes in the way the functions are called in the example page (using setTimeout to allow the items to not block the UI thread and, thus, render faster) but they aren't related to my changes to close-pixelate.js

I've got a couple more changes in mind. Next up are allowing offset to accept an [x,y] array, and removing the functions as DOM extensions and just making them regular functions which accept element(s) to pixelate. I'm sure new shapes would be useful, too.

Anyway, thanks for the code and the mental exercise. I'm rather happy with how it came out.

Cheers,
John
