### PR TITLE
Data urls

### DIFF
--- a/close-pixelate.js
+++ b/close-pixelate.js
@@ -54,7 +54,7 @@ function ClosePixelation( img, options ) {
   canvas.id = img.id
 
   this.img.onload = function() {
-    this.render( options )
+    cp.render( options )
   }
 
   // replace image with canvas

--- a/close-pixelate.js
+++ b/close-pixelate.js
@@ -42,7 +42,10 @@ if ( !isCanvasSupported ) {
 
 
 function ClosePixelation( img, options ) {
-  this.img = img
+  var cp = this
+
+  this.img = new Image()
+  this.img.src = img.src
   // creat canvas
   var canvas = this.canvas = document.createElement('canvas')
   this.ctx = canvas.getContext('2d')
@@ -50,7 +53,9 @@ function ClosePixelation( img, options ) {
   canvas.className = img.className
   canvas.id = img.id
 
-  this.render( options )
+  this.img.onload = function() {
+    this.render( options )
+  }
 
   // replace image with canvas
   img.parentNode.replaceChild( canvas, img )


### PR DESCRIPTION
Hello desandro,

I was recently using this library for a page on which I had a drag-and-drop interface that loaded local images. I had one image on the page, and as a FileReader would load a local copy, the image src attribute was a data url. I ran into the problem that the computed height of the new canvas object created by close-pixelate was always 0. I have made a modification that loads the img element's src attribute into an Image object, and ClosePixellate does not call render() until the Image has completely loaded. This has resolved the issue.

Please let me know if there is a sample you would like me to provide or if you would like more information about what I am using this library for.

Thanks!
Wes
